### PR TITLE
Bugfix in Java version check

### DIFF
--- a/R/init.R
+++ b/R/init.R
@@ -221,5 +221,5 @@ check_valid_java_version <- function(){
   jv <- rJava::.jcall("java/lang/System", "S", "getProperty", "java.version")
   if(jv < "1.8.0")
     return (FALSE)
-  substr(jv, 1L, 3L) == "1.8" || jv <="15"
+  substr(jv, 1L, 3L) == "1.8" || jv <="15."
 }

--- a/R/init.R
+++ b/R/init.R
@@ -221,5 +221,6 @@ check_valid_java_version <- function(){
   jv <- rJava::.jcall("java/lang/System", "S", "getProperty", "java.version")
   if(jv < "1.8.0")
     return (FALSE)
-  substr(jv, 1L, 3L) == "1.8" || jv <="15."
+  jv_stub <- substr(jv, 1L, 3L) 
+  jv_stub == "1.8" || jv_stub <="15."
 }

--- a/R/init.R
+++ b/R/init.R
@@ -219,8 +219,5 @@ rjdemetra_java$clobject <- NULL
 check_valid_java_version <- function(){
   # Check Java version
   jv <- rJava::.jcall("java/lang/System", "S", "getProperty", "java.version")
-  if(jv < "1.8.0")
-    return (FALSE)
-  jv_stub <- substr(jv, 1L, 3L) 
-  jv_stub == "1.8" || jv_stub <="15."
+  jv >= "1.8.0" && substr(jv, 1L, 3L) <= "15."
 }

--- a/R/init.R
+++ b/R/init.R
@@ -217,7 +217,7 @@ rjdemetra_java <- new.env(parent = emptyenv())
 rjdemetra_java$clobject <- NULL
 
 check_valid_java_version <- function(){
-  # Check Java version
+  # Check Java version >= 8 and <= 15
   jv <- rJava::.jcall("java/lang/System", "S", "getProperty", "java.version")
   jv >= "1.8.0" && substr(jv, 1L, 3L) <= "15."
 }


### PR DESCRIPTION
Thanks for the great work on this package!

Currently, Java 15.x.x versions are rejected (d172c8a, introduced in #93).
```r
> jv <- "15.0.1"
> jv <= 15
[1] FALSE
```

With this fix, Java 15 versions are accepted, as well as any legacy Java versions labeled 1.9.x (= Java 9) and 1.10.x (= Java 10).
```r
> jv <- "15.0.1"
> jv >= "1.8.0" && substr(jv, 1L, 3L) <= "15."
[1] TRUE
```

This is tested on R 4.1.2 for MacOS Monterey with an M1 chip (64-bit arch) and Java version 15.0.6 as reported by 
```r
rJava::.jcall("java/lang/System", "S", "getProperty", "java.version")
```
Note that running the minimal example from the README (`ipi_c_eu`) works with Java 15.0.6, but produces an illegal reflective access warning:
```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by RJavaTools to method java.util.Collections$UnmodifiableCollection.isEmpty()
WARNING: Please consider reporting this to the maintainers of RJavaTools
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```
I don't have all the context, but I suspect that this is known behavior – I'm guessing that the Java version restriction is because of Java 16's `--illegal-access=deny` default behavior. This is obviously an upstream issue in JDemetra+; judging by [this comment](https://github.com/jdemetra/rjdemetra/blob/master/NEWS.md?plain=1#L15), I further suspect that this warning will be resolved in the next JDemetra+ release.