### PR TITLE
Use full path when loading/saving workspaces

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 - New function `get_all_names()` and `get_position()`
 
+- correction of `save_workspace()` when using relative path.
 
 # RJDemetra 0.2.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,8 @@
-# RJDemetra development version
+# RJDemetra 0.2.4
 
-- New function `get_all_names()` and `get_position()`
+- New function `get_all_names()` and `get_position()`.
 
-- correction of `save_workspace()` when using relative path.
+- correction of `save_workspace()` and  `load_workspace()` when using relative path.
 
 # RJDemetra 0.2.3
 
@@ -11,11 +11,11 @@
 
 # RJDemetra 0.2.2
 
-- update documentation
+- update documentation.
 
-- removes extra argument print tramo
+- removes extra argument print tramo.
 
-- SystemRequirements update for CRAN policies
+- SystemRequirements update for CRAN policies.
 
 
 # RJDemetra 0.2.1

--- a/R/export_workspace.R
+++ b/R/export_workspace.R
@@ -75,18 +75,18 @@ save_workspace <- function(workspace, file) {
   if (length(grep("\\.xml$",file)) == 0)
     stop("The file must be a .xml !")
 
-  full_file_name <- normalizePath(file, winslash = "/", mustWork = FALSE)
-  folder_wk_name <- sub(".xml$","", full_file_name)
-  workspace_name <- basename(folder_wk_name)
-
+  full_file_name <- full_path(file)
 
   result <- .jcall(workspace, "Z", "save", full_file_name)
-  # To change the name of the workspace
-  wk_txt <- readLines(full_file_name)
-  wk_txt <- sub(folder_wk_name, workspace_name, wk_txt)
-  writeLines(wk_txt, full_file_name)
 
   invisible(result)
+}
+
+full_path <- function(path) {
+  base::file.path(
+    base::normalizePath(dirname(path), mustWork = TRUE, winslash = "/"),
+    base::basename(path),
+    fsep = "/")
 }
 
 

--- a/R/import_workspace.R
+++ b/R/import_workspace.R
@@ -38,7 +38,9 @@ load_workspace <- function(file){
   if (!file.exists(file) | length(grep("\\.xml$",file)) == 0)
     stop("The file doesn't exist or isn't a .xml file !")
 
-  workspace <- .jcall("ec/tstoolkit/jdr/ws/Workspace", "Lec/tstoolkit/jdr/ws/Workspace;", "open", file)
+  full_file_name <- full_path(file)
+  workspace <- .jcall("ec/tstoolkit/jdr/ws/Workspace", "Lec/tstoolkit/jdr/ws/Workspace;", "open",
+                      full_file_name)
   workspace <- new("workspace", workspace)
   return(workspace)
 }


### PR DESCRIPTION
full path is now used loading/saving workspaces to avoid some problems with relative path (for example executing a code in rmarkdown file)